### PR TITLE
Long press gesture recognizer was added multiple times.

### DIFF
--- a/BVReorderTableView.m
+++ b/BVReorderTableView.m
@@ -82,8 +82,10 @@
 
 
 - (void)initialize {
-    longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPress:)];
-    [self addGestureRecognizer:longPress];
+    if (!longPress) {
+        longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPress:)];
+        [self addGestureRecognizer:longPress];
+    }
     
     self.canReorder = YES;
 }


### PR DESCRIPTION
If longPress gesture recognizer has already been added, we shouldn't add it again.
Otherwise, the boolean canReorder won't work well if it's initialized multiple times.
