### PR TITLE
Allow conditional disabling of row re-ordering 

### DIFF
--- a/BVReorderTableView.m
+++ b/BVReorderTableView.m
@@ -107,8 +107,12 @@
     }
     
     // get out of here if the long press was not on a valid row or our table is empty
+    // or the dataSource tableView:canMoveRowAtIndexPath: doesn't allow moving the row
     if (rows == 0 || (gesture.state == UIGestureRecognizerStateBegan && indexPath == nil) ||
-        (gesture.state == UIGestureRecognizerStateEnded && self.currentLocationIndexPath == nil)) {
+        (gesture.state == UIGestureRecognizerStateEnded && self.currentLocationIndexPath == nil) ||
+        (gesture.state == UIGestureRecognizerStateBegan &&
+         [self.dataSource respondsToSelector:@selector(tableView:canMoveRowAtIndexPath:)] &&
+         indexPath && ![self.dataSource tableView:self canMoveRowAtIndexPath:indexPath])) {
         [self cancelGesture];
         return;
     }


### PR DESCRIPTION
I needed to be able to conditionally disable re-ordering of certain rows. Since the `UITableViewDataSource` protocol already has the method `tableView:canMoveRowAtIndexPath:` I decided that would be the cleanest way to check if a row can be moved or not. The method is only checked if the dataSource implementation implements it.

At the start of the long press gesture, if the dataSource implements `tableView:canMoveRowAtIndexPath:` and it returns NO then the gesture is cancelled.
