### PR TITLE
Modified scrolling to use CADisplayLink instead of NSTimer.

### DIFF
--- a/BVReorderTableView.h
+++ b/BVReorderTableView.h
@@ -45,6 +45,7 @@
 
 @property (nonatomic, assign) id <ReorderTableViewDelegate> delegate;
 @property (nonatomic, assign) CGFloat draggingRowHeight;
+@property (nonatomic, assign) CGFloat draggingViewOpacity;
 @property (nonatomic, assign) BOOL canReorder;
 
 @end

--- a/BVReorderTableView.m
+++ b/BVReorderTableView.m
@@ -54,6 +54,7 @@
 @synthesize draggingView;
 @synthesize savedObject;
 @synthesize draggingRowHeight;
+@synthesize draggingViewOpacity;
 @synthesize initialIndexPath;
 
 - (id)init {
@@ -86,6 +87,7 @@
     [self addGestureRecognizer:longPress];
     
     self.canReorder = YES;
+    self.draggingViewOpacity = 1.0;
 }
 
 
@@ -145,7 +147,7 @@
             draggingView.layer.shadowOffset = CGSizeMake(0, 0);
             draggingView.layer.shadowRadius = 4.0;
             draggingView.layer.shadowOpacity = 0.7;
-            //draggingView.layer.opacity = 0.8;
+            draggingView.layer.opacity = self.draggingViewOpacity;
             
             // zoom image towards user
             [UIView beginAnimations:@"zoom" context:nil];


### PR DESCRIPTION
Much less CPU intensive and avoids having to choose a timer interval, which due
to a bug was being set a 0.001 milliseconds (10,000 times per second!)
Multplied scrollRate by a factor of 10 for faster scrolling.

See the [this discussion](https://github.com/bvogelzang/BVReorderTableView/commit/bd6f75811913ed38237b2b1ec5c8b6844552eb1d#commitcomment-4580889) for more info.

Thanks to @leocassarani for the heads up.
