### PR TITLE
Added ReorderTableViewDataSource and canMoveRowFromIndexPath:toIndexPath...

### DIFF
--- a/BVReorderTableView.h
+++ b/BVReorderTableView.h
@@ -24,6 +24,13 @@
 
 #import <UIKit/UIKit.h>
 
+@protocol ReorderTableViewDataSource <UITableViewDataSource>
+
+// TODO: Description of this delegate method
+- (BOOL)canMoveRowFromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath;
+
+@end
+
 @protocol ReorderTableViewDelegate <UITableViewDelegate>
 
 // This method is called when starting the re-ording process. You insert a blank row object into your
@@ -44,6 +51,7 @@
 @interface BVReorderTableView : UITableView
 
 @property (nonatomic, assign) id <ReorderTableViewDelegate> delegate;
+@property (nonatomic, assign) id <ReorderTableViewDataSource> dataSource;
 @property (nonatomic, assign) CGFloat draggingRowHeight;
 @property (nonatomic, assign) CGFloat draggingViewOpacity;
 @property (nonatomic, assign) BOOL canReorder;

--- a/BVReorderTableView.m
+++ b/BVReorderTableView.m
@@ -254,6 +254,7 @@
     
     NSIndexPath *indexPath  = nil;
     CGPoint location = CGPointZero;
+    BOOL canMove = YES;
     
     // refresh index path
     location  = [gesture locationInView:self];
@@ -263,10 +264,14 @@
         indexPath = [self.delegate tableView:self targetIndexPathForMoveFromRowAtIndexPath:self.initialIndexPath toProposedIndexPath:indexPath];
     }
     
+    if ([self.dataSource respondsToSelector:@selector(canMoveRowFromIndexPath:toIndexPath:)]) {
+        canMove = [self.dataSource canMoveRowFromIndexPath:self.currentLocationIndexPath toIndexPath:indexPath];
+    }
+    
     NSInteger oldHeight = [self rectForRowAtIndexPath:self.currentLocationIndexPath].size.height;
     NSInteger newHeight = [self rectForRowAtIndexPath:indexPath].size.height;
     
-    if (indexPath && ![indexPath isEqual:self.currentLocationIndexPath] && [gesture locationInView:[self cellForRowAtIndexPath:indexPath]].y > newHeight - oldHeight) {
+    if (canMove && indexPath && ![indexPath isEqual:self.currentLocationIndexPath] && [gesture locationInView:[self cellForRowAtIndexPath:indexPath]].y > newHeight - oldHeight) {
         [self beginUpdates];
         [self deleteRowsAtIndexPaths:[NSArray arrayWithObject:self.currentLocationIndexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
         [self insertRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];

--- a/BVReorderTableView.podspec
+++ b/BVReorderTableView.podspec
@@ -1,0 +1,40 @@
+Pod::Spec.new do |s|
+  s.name         = "BVReorderTableView"
+  s.version      = "1.0.0"
+  s.summary      = "Easy Long Press Reordering for UITableView."
+  s.homepage     = "https://github.com/bvogelzang/BVReorderTableView"
+  s.screenshots  = "https://raw.github.com/bvogelzang/BVReorderTableView/master/Screenshot1.png"
+  s.license      = {
+    :type => 'MIT',
+    :text => <<-LICENSE
+      The MIT License (MIT)
+
+      Copyright (c) 2013 Ben Vogelzang
+
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+    LICENSE
+  }
+  s.author       = { "Ben Vogelzang" => "bvogelzang@breuer.com" }
+  s.source       = { :git => "https://github.com/bvogelzang/BVReorderTableView.git", :tag => "1.0.0" }
+  s.platform     = :ios, '5.0'
+  s.source_files = 'BVReorderTableView.{h,m}'
+  s.exclude_files = 'Classes/Exclude'
+  s.frameworks  = 'UIKit', 'QuartzCore'
+  s.requires_arc = true
+end


### PR DESCRIPTION
It's just a dataSource and dataSource method which can prevent from dragging rows between sections etc.
For example if I want to allow moving rows in same section:

``` objective-c
- (BOOL)canMoveRowFromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath
{
    if (fromIndexPath.section == toIndexPath.section) {
        return YES;
    }
    return NO;
}
```
