### PR TITLE
Allow delegate to override the dragged cell

### DIFF
--- a/BVReorderTableView.h
+++ b/BVReorderTableView.h
@@ -39,6 +39,13 @@
 // object you returned in saveObjectAndInsertBlankRowAtIndexPath:. Simply update the data source so the
 // object is in its new position. You should do any saving/cleanup here.
 - (void)finishReorderingWithObject:(id)object atIndexPath:(NSIndexPath *)indexPath;
+
+@optional
+
+// This method is called when dragging begins. The delegate can return a non-nil object if
+// it wishes to replace the dragged cell with something else.
+- (UITableViewCell *)cellForDraggingAtIndexPath:(NSIndexPath *)indexPath;
+
 @end
 
 @interface BVReorderTableView : UITableView

--- a/BVReorderTableView.m
+++ b/BVReorderTableView.m
@@ -122,7 +122,13 @@
     // started
     if (gesture.state == UIGestureRecognizerStateBegan) {
         
-        UITableViewCell *cell = [self cellForRowAtIndexPath:indexPath];
+        UITableViewCell *cell = nil;
+        if ([self.delegate respondsToSelector:@selector(cellForDraggingAtIndexPath:)]) {
+            cell = [self.delegate cellForDraggingAtIndexPath:indexPath];
+        }
+        if (cell == nil) {
+            [self cellForRowAtIndexPath:indexPath];
+        }
         self.draggingRowHeight = cell.frame.size.height;
         [cell setSelected:NO animated:NO];
         [cell setHighlighted:NO animated:NO];

--- a/BVReorderTableView.m
+++ b/BVReorderTableView.m
@@ -127,7 +127,7 @@
             cell = [self.delegate cellForDraggingAtIndexPath:indexPath];
         }
         if (cell == nil) {
-            [self cellForRowAtIndexPath:indexPath];
+            cell = [self cellForRowAtIndexPath:indexPath];
         }
         self.draggingRowHeight = cell.frame.size.height;
         [cell setSelected:NO animated:NO];


### PR DESCRIPTION
When drag starts, asks the delegate if it wants to provide a different
cell for dragging. This gives the delegate some freedom to hide,
modify, etc things before drag starts.
